### PR TITLE
feat: allow for injected functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ However, Pulumi's serializer had a few short comings:
 * Removed: Pulumi Logging support
 * Change: `serialize` function support replacement of runtime data to be serialized on top of avoiding serialization
 * Change: [Do not serialize functions and constructors that are not invoked](https://github.com/functionless/nodejs-closure-serializer/pull/8)
+* Change: Anonymous functions can be injected at runtime through the serialize callback.
 
 ## Forked from
 

--- a/src/closure/createClosure.ts
+++ b/src/closure/createClosure.ts
@@ -401,11 +401,6 @@ async function analyzeFunctionInfoAsync(
   }
 
   async function serializeWorkerAsync(): Promise<FunctionInfo> {
-    const funcEntry = context.cache.get(func);
-    if (!funcEntry) {
-      throw new Error("Entry for this this function was not created by caller");
-    }
-
     // First, convert the js func object to a reasonable stringified version that we can operate on.
     // Importantly, this function helps massage all the different forms that V8 can produce to
     // either a "function (...) { ... }" form, or a "(...) => ..." form.  In other words, all
@@ -561,6 +556,13 @@ async function analyzeFunctionInfoAsync(
     // i.e. the inner call to "f();" will actually call the *outer* __f function, and not
     // itself.
     if (functionDeclarationName !== undefined) {
+      const funcEntry = context.cache.get(func);
+      if (!funcEntry) {
+        throw new Error(
+          "Entry for this this function was not created by caller"
+        );
+      }
+
       capturedValues.set(
         await getOrCreateNameEntryAsync(
           functionDeclarationName,


### PR DESCRIPTION
Allows for the `serialize` function to accept Function expr or Arrow Expr and return values.

previously `serialize` would throw an error when a function was returned.