### PR TITLE
feat: add hook for excluding specific properties from serialization

### DIFF
--- a/src/closure/serializeClosure.ts
+++ b/src/closure/serializeClosure.ts
@@ -30,6 +30,13 @@ export interface SerializeFunctionArgs {
    */
   serialize: (o: any) => boolean | any;
   /**
+   * A function to prevent serialization of a {@link property} on an {@link obj}
+   *
+   * @param obj the object containing the property
+   * @param property the value of the property name
+   */
+  shouldCaptureProp?: (obj: any, property: string | number | symbol) => boolean;
+  /**
    * List of transformers to apply to closures.
    */
   transformers?: ts.TransformerFactory<ts.Node>[];

--- a/test/__snapshots__/closureLoader.spec.ts.snap
+++ b/test/__snapshots__/closureLoader.spec.ts.snap
@@ -4708,6 +4708,7 @@ function __f0() {
     let a = undefined;
 
     return function () {
+                // @ts-ignore
                 const x = typeof a;
             };
   }).apply(undefined, undefined).apply(this, arguments);
@@ -4727,6 +4728,39 @@ function __f0(__0, __1, __2) {
                 const v = os;
                 return { v };
             };
+  }).apply(undefined, undefined).apply(this, arguments);
+}",
+}
+`;
+
+exports[`after hooks closure exclude properties on function 1`] = `
+Object {
+  "exportName": "handler",
+  "text": "exports.handler = __foo;
+function __foo() {
+  return (function() {
+    let foo = __foo;
+
+    return function /*foo*/() { };
+  }).apply(undefined, undefined).apply(this, arguments);
+}",
+}
+`;
+
+exports[`after hooks closure exclude properties on object 1`] = `
+Object {
+  "exportName": "handler",
+  "text": "exports.handler = __foo;
+
+var __free = {};
+function __foo() {
+  return (function() {
+    let free = __free;
+    let foo = __foo;
+
+    return function /*foo*/() {
+            return free;
+        };
   }).apply(undefined, undefined).apply(this, arguments);
 }",
 }


### PR DESCRIPTION
- [x] adds a `shouldCaptureProp` hook for excluding properties from serialization.

```ts
serializeFunction({
  shouldCaptureProp: (obj, prop) => typeof obh === "function" && prop === "bad name"
});
```

- [x] when transforming closures, unwrap a `ExpressionStatement(ParenthesizedExpression(FunctionExpression))` to a single `FunctionExpression`