### PR TITLE
fix: ignore $jsDebugIsRegistered

### DIFF
--- a/src/closure/createClosure.ts
+++ b/src/closure/createClosure.ts
@@ -259,7 +259,11 @@ export async function createClosureInfoAsync(
       for (const key of Object.getOwnPropertyNames(current)) {
         // "GLOBAL" and "root" are deprecated and give warnings if you try to access them.  So
         // just skip them.
-        if (key !== "GLOBAL" && key !== "root") {
+        if (
+          key !== "GLOBAL" &&
+          key !== "root" &&
+          key !== "$jsDebugIsRegistered"
+        ) {
           await addGlobalInfoAsync(key);
         }
       }


### PR DESCRIPTION
Strange bug where vs code (and other test tools) set a `global["$jsDebugIsRegistered"]` with a getter that, when called, throws an exception. This change is a quick hack to ignore serializing that property - it should never impact prod.