### PR TITLE
feat: upgrade to typescript 4.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,10 +48,10 @@
     "projen": "^0.56.29",
     "standard-version": "^9",
     "ts-jest": "^27",
-    "typescript": "^4.7.2"
+    "typescript": "^4.8.3"
   },
   "peerDependencies": {
-    "typescript": "^4.7.4"
+    "typescript": "^4.8.3"
   },
   "dependencies": {
     "normalize-package-data": "^4.0.0",

--- a/src/closure/rewriteSuper.ts
+++ b/src/closure/rewriteSuper.ts
@@ -66,12 +66,11 @@ export function rewriteSuperReferences(
         const text = utils.isLegalMemberName(funcDecl.name!.text)
           ? "/*" + funcDecl.name!.text + "*/"
           : "";
-        return ts.updateFunctionDeclaration(
+        return ts.factory.updateFunctionDeclaration(
           funcDecl,
-          funcDecl.decorators,
           funcDecl.modifiers,
           funcDecl.asteriskToken,
-          ts.createIdentifier(text),
+          ts.factory.createIdentifier(text),
           funcDecl.typeParameters,
           funcDecl.parameters,
           funcDecl.type,
@@ -80,7 +79,7 @@ export function rewriteSuperReferences(
       }
 
       if (node.kind === ts.SyntaxKind.SuperKeyword) {
-        const newNode = ts.createIdentifier("__super");
+        const newNode = ts.factory.createIdentifier("__super");
         newNodes.add(newNode);
         return newNode;
       } else if (

--- a/yarn.lock
+++ b/yarn.lock
@@ -5883,10 +5883,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.7.2:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+typescript@^4.8.3:
+  version "4.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
+  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
 
 uglify-js@^3.1.4:
   version "3.15.5"


### PR DESCRIPTION
TypeScript combined decorators and modifiers in their AST which was breaking the serializer when upgrading to ts 4.8.3. 